### PR TITLE
handle 32-bit lua_Integer typedef

### DIFF
--- a/lua-affinity.c
+++ b/lua-affinity.c
@@ -36,7 +36,7 @@
 
 #include "cpuset-str.h"
 
-#define MAX_LUAINT (0xfffffffffffff0)
+#define MAX_LUAINT ((1ULL<<(8*(sizeof(lua_Integer)-1)))-0x10)
 
 static cpu_set_t * l_cpu_set_alloc (lua_State *L)
 {


### PR DESCRIPTION
Problem: MAX_LUAINT is hardwired to a value that cannot be returned
by lua_tointeger() if lua_Integer is defined as a 32-bit type,
such as with packaged lua5.1 (5.1.5-7.1) on raspbian jessie.

Define MAX_LUAINT to a macro based on sizeof(lua_Integer) that
resolves to the previous hardwired value if lua_Integer is 64 bits.

Fixes #1