### PR TITLE
lua-affinity: improve overflow detection

### DIFF
--- a/lua-affinity.c
+++ b/lua-affinity.c
@@ -78,7 +78,7 @@ static int lua_number_to_cpu_setp (lua_State *L, int index, cpu_set_t *setp)
     char buf [1024];
     unsigned long long n = lua_tointeger (L, index);
 
-    if (n >= (unsigned long long) MAX_LUAINT) {
+    if (n >= (unsigned long long) MAX_LUAINT || lua_tonumber (L, index) != n) {
         lua_pushnil (L);
         lua_pushfstring (L, "unable to parse CPU mask: numeric overflow");
         return (2);


### PR DESCRIPTION
Problem: lua-affinity overflow test fails on 32-bit i686
system, returning 0xff instead of an overflow value.

On this system MAX_LUAINT is 0xfffff0 (2^24 - 16).
The overflow test value is 0xffffffffffffffff (2^64 - 1).
Overflow occurs if the lua_tointeger() >= MAX_LUAINT.

The lua5.1 documentation says of lua_tointeger() that
"if the a number is not an integer it is truncated
in some unspecified way".

Assuming a number that is too large to represent as
an integer might be considered "not an integer",
perhaps that explains the odd result of 0xff?

Since lua_tonumber() returns a double with greater
range than lua_tointeger(), add a check that the
two functions return equal values.  They should
match if the number is a valid integer.